### PR TITLE
Map deploy environments to AWS accounts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,10 +31,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Select AWS account
+        run: |
+          if [ "${{ github.event.inputs.environment }}" = "general" ]; then
+            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_GENERAL }}" >> "$GITHUB_ENV"
+          elif [ "${{ github.event.inputs.environment }}" = "production" ]; then
+            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_PRODUCTION }}" >> "$GITHUB_ENV"
+          elif [ "${{ github.event.inputs.environment }}" = "development" ]; then
+            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_DEVELOPMENT }}" >> "$GITHUB_ENV"
+          else
+            echo "Unknown environment: ${{ github.event.inputs.environment }}" >&2
+            exit 1
+          fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy CloudFormation stack


### PR DESCRIPTION
## Summary
- map workflow environments to AWS account IDs via secrets
- assume deployment role in selected account before CloudFormation deploy

## Testing
- `bash start.test`


------
https://chatgpt.com/codex/tasks/task_e_68af7d441cfc8322a5390bb7e5641a4e