### PR TITLE
Add option to delete all CloudFormation stacks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
         options:
           - VPC-3Public3Private
           - EC2-Ansible
+          - ALL
       environment:
         description: 'Deployment environment'
         type: choice
@@ -68,7 +69,16 @@ jobs:
           no-fail-on-empty-changeset: '1'
 
       - name: Delete CloudFormation stack
-        if: ${{ github.event.inputs.action == 'delete' }}
+        if: ${{ github.event.inputs.action == 'delete' && github.event.inputs.template != 'ALL' }}
         run: |
           aws cloudformation delete-stack --stack-name ${{ github.event.inputs.template }}
           aws cloudformation wait stack-delete-complete --stack-name ${{ github.event.inputs.template }}
+
+      - name: Delete all CloudFormation stacks
+        if: ${{ github.event.inputs.action == 'delete' && github.event.inputs.template == 'ALL' }}
+        run: |
+          for template_file in templates/*.yaml; do
+            stack_name=$(basename "$template_file" .yaml)
+            aws cloudformation delete-stack --stack-name "$stack_name"
+            aws cloudformation wait stack-delete-complete --stack-name "$stack_name"
+          done


### PR DESCRIPTION
## Summary
- allow selecting ALL templates in dispatch workflow
- support deleting every CloudFormation stack when ALL is chosen

## Testing
- `yamllint -d "{extends: default, rules: {line-length: {max: 160}, truthy: disable}}" .github/workflows/deploy.yml`

------
https://chatgpt.com/codex/tasks/task_e_68af9a0713b48322a9db9d18d19d2cf0