### PR TITLE
Add CloudFormation template for Python Lambda function

### DIFF
--- a/templates/Lambda-Python.yaml
+++ b/templates/Lambda-Python.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Deploy a Python-based AWS Lambda function with a basic execution role.
+
+Parameters:
+  FunctionName:
+    Type: String
+    Default: HelloLambda
+    Description: Name of the Lambda function
+
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      Runtime: python3.9
+      Handler: index.lambda_handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        ZipFile: |
+          import json
+
+          def lambda_handler(event, context):
+              return {
+                  'statusCode': 200,
+                  'body': json.dumps('Hello from Lambda!')
+              }
+
+Outputs:
+  FunctionName:
+    Description: Name of the created Lambda function
+    Value: !Ref LambdaFunction
+  RoleArn:
+    Description: ARN of the Lambda execution role
+    Value: !GetAtt LambdaExecutionRole.Arn


### PR DESCRIPTION
## Summary
- add CloudFormation template to deploy a simple Python Lambda with basic execution role

## Testing
- `python -m py_compile deploy.py`
- `cfn-lint templates/Lambda-Python.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b061e61da4832295924380a41d1c1c