### PR TITLE
Add basic Python Lambda CloudFormation template

### DIFF
--- a/templates/Lambda-BasicPython.yaml
+++ b/templates/Lambda-BasicPython.yaml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Basic AWS Lambda function written in Python
+
+Resources:
+  BasicLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: BasicPythonLambda
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: python3.9
+      Code:
+        ZipFile: |
+          import json
+          def handler(event, context):
+              return {
+                  'statusCode': 200,
+                  'body': json.dumps('Hello from Lambda!')
+              }
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+Outputs:
+  LambdaFunctionArn:
+    Description: ARN of the Lambda function
+    Value: !GetAtt BasicLambdaFunction.Arn


### PR DESCRIPTION
## Summary
- add sample CloudFormation template for a Python Lambda function

## Testing
- `cfn-lint templates/Lambda-BasicPython.yaml`
- `python -m py_compile deploy.py`

## Labels
- automerge

------
https://chatgpt.com/codex/tasks/task_e_68b0697125348322acdb2266b7c102f6