### PR TITLE
Add basic Lambda function CloudFormation template

### DIFF
--- a/templates/Lambda-Basic.yaml
+++ b/templates/Lambda-Basic.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Deploys a simple Lambda function with basic execution permissions.
+
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  HelloFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: hello-function
+      Runtime: python3.9
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        ZipFile: |
+          import json
+
+          def handler(event, context):
+            return {
+              "statusCode": 200,
+              "body": json.dumps("Hello from Lambda!")
+            }
+
+Outputs:
+  FunctionName:
+    Description: Name of the created Lambda function
+    Value: !Ref HelloFunction


### PR DESCRIPTION
## Summary
- add CloudFormation template for a Python Lambda function with basic execution role

## Testing
- `cfn-lint templates/Lambda-Basic.yaml && echo "Lint OK"`

Labels: automerge

------
https://chatgpt.com/codex/tasks/task_e_68b097e9591c8322a6c75407ff32d38e