### PR TITLE
Add automerge workflow with lint check

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,38 @@
+---
+name: Lint and Automerge
+
+'on':
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install flake8
+        run: pip install flake8
+      - name: Run flake8
+        run: flake8 .
+      - name: Add automerge label
+        if: ${{ always() && github.event.pull_request.head.repo.fork == false }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: automerge
+
+  automerge:
+    needs: lint
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- add workflow to run flake8 and auto-merge PRs
- label pull requests with `automerge`

## Testing
- `yamllint .github/workflows/automerge.yml`
- `flake8` *(fails: E501 line too long in deploy.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b099d6add48322b941e27200f2ecee