### PR TITLE
Allow automerge without lint check

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,27 @@
+---
+name: Automerge
+
+'on':
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Add automerge label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: automerge
+      - name: Enable auto-merge
+        continue-on-error: true
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- remove flake8 lint from automerge workflow
- label pull requests `automerge` and enable auto-merge
- ignore errors when enabling auto-merge to avoid job failures

## Testing
- `yamllint .github/workflows/automerge.yml`
- `flake8` *(fails: E501 line too long in deploy.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b099d6add48322b941e27200f2ecee