### PR TITLE
fix: pass PR number to automerge action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
+          pull-request-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- ensure automerge workflow specifies pull request number

## Testing
- `python -m py_compile deploy.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0a1832d288322a8dcb1a2c4142a8b